### PR TITLE
feat(codegen): render named types for protocol custom types

### DIFF
--- a/.trix/client-lib/lib.rs.hbs
+++ b/.trix/client-lib/lib.rs.hbs
@@ -57,6 +57,10 @@ pub static {{constantCase @key}}_TIR: LazyLock<TirEnvelope> = LazyLock::new(|| T
 });
 {{/each}}
 
+{{#if tii.components.schemas}}
+// Named types for the protocol's custom (record / variant) types.
+{{{componentTypes tii.components.schemas "rust"}}}
+{{/if}}
 {{#each tii.transactions}}
 /// Arguments for the {{@key}} transaction.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## What

Declare a named type per `components.schemas` entry in the generated client:
a full struct/interface/dataclass for records, and a permissive named alias
for variants (pending the variant arg encoder).

Driven by the new `componentTypes` helper in `tx3c codegen`.

Pairs with `tx3-lang/tx3` (emitter + codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
