### PR TITLE
feat(tii)!: interpret the full complex param-type model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,12 +156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
 name = "ed25519-bip32"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,30 +941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,17 +954,6 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1263,7 +1222,6 @@ dependencies = [
  "pallas-addresses",
  "pallas-crypto",
  "reqwest",
- "schemars",
  "serde",
  "serde_json",
  "thiserror",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = "2.0.12"
 hex = "0.4.3"
 base64 = "0.22.1"
 bech32 = "0.11.0"
-schemars = { version = "0.8", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "time"], default-features = false }
 bip39 = { version = "2.0", features = ["rand"] }
 pallas-addresses = "1.0.0"

--- a/sdk/src/tii/mod.rs
+++ b/sdk/src/tii/mod.rs
@@ -74,7 +74,10 @@ use crate::{
     tii::spec::{Profile, Transaction},
 };
 
+mod schema;
 pub mod spec;
+
+pub use schema::{ParamMap, ParamType, VariantCase};
 
 /// Error type for TII operations.
 ///
@@ -97,30 +100,6 @@ pub enum Error {
     /// Profile name not found in the protocol.
     #[error("unknown profile: {0}")]
     UnknownProfile(String),
-
-    /// Invalid JSON schema for transaction parameters.
-    #[error("invalid params schema")]
-    InvalidParamsSchema,
-
-    /// Invalid parameter type encountered in schema.
-    #[error("invalid param type")]
-    InvalidParamType,
-}
-
-/// Builds a parameter-type map from a JSON schema's `properties`. Never fails:
-/// unrecognized property schemas yield [`ParamType::Unknown`]. `components` is the
-/// TII's `components.schemas` table, used to resolve `#/components/schemas/<Name>`
-/// refs to user-defined record / variant types.
-fn params_from_schema(schema: &Value, components: &HashMap<String, Value>) -> ParamMap {
-    let mut params = ParamMap::new();
-
-    if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
-        for (key, value) in properties {
-            params.insert(key.clone(), ParamType::from_json_schema(value, components));
-        }
-    }
-
-    params
 }
 
 /// A TX3 protocol loaded from a TII file.
@@ -304,10 +283,10 @@ impl Protocol {
         }
 
         if let Some(env) = &self.spec.environment {
-            out.params.extend(params_from_schema(env, &components));
+            out.params.extend(schema::params_from_schema(env, &components));
         }
 
-        out.params.extend(params_from_schema(&tx.params, &components));
+        out.params.extend(schema::params_from_schema(&tx.params, &components));
 
         if let Some(profile) = profile {
             if let Some(env) = profile.environment.as_object() {
@@ -354,174 +333,10 @@ impl Protocol {
     }
 }
 
-/// Type of a transaction parameter.
-///
-/// This enum represents the various types that transaction parameters can have,
-/// including primitives, compound types, and references to TX3 core types. It is
-/// built from the TII params JSON schema by [`ParamType::from_json_schema`], which
-/// never fails — any shape it does not recognize becomes [`ParamType::Unknown`].
-#[derive(Debug, Clone)]
-pub enum ParamType {
-    /// Byte array type (hex-encoded).
-    Bytes,
-    /// Integer type (signed or unsigned).
-    Integer,
-    /// Boolean type.
-    Boolean,
-    /// Unit type (`{ "type": "null" }`).
-    Unit,
-    /// UTXO reference in format `0x[64hex]#[index]`.
-    UtxoRef,
-    /// Bech32-encoded blockchain address.
-    Address,
-    /// A resolved UTxO object.
-    Utxo,
-    /// An asset identified at runtime by policy and name.
-    AnyAsset,
-    /// Homogeneous, variable-length sequence (`array` + `items`).
-    List(Box<ParamType>),
-    /// Fixed-length, positionally-typed sequence (`array` + `prefixItems`).
-    Tuple(Vec<ParamType>),
-    /// String-keyed homogeneous map (`object` + `additionalProperties`).
-    Map(Box<ParamType>),
-    /// User-defined record (`object` + `properties`), field name → type.
-    Record(BTreeMap<String, ParamType>),
-    /// User-defined tagged union (`oneOf`), externally tagged.
-    Variant(Vec<VariantCase>),
-    /// A schema shape that could not be interpreted; carries the raw schema.
-    Unknown(Value),
-}
-
-/// One case of a [`ParamType::Variant`].
-#[derive(Debug, Clone)]
-pub struct VariantCase {
-    /// The case tag (the single `required` key of the externally-tagged object).
-    pub tag: String,
-    /// The case payload (typically a [`ParamType::Record`]).
-    pub fields: Box<ParamType>,
-}
-
-impl ParamType {
-    /// Maps a built-in core `$ref` to its kind by trailing name, so both the
-    /// canonical `…/tii#/$defs/<Name>` and legacy `…/core#<Name>` forms resolve.
-    fn core_ref_type(reference: &str) -> Option<ParamType> {
-        let name = reference.rsplit(['#', '/']).next().unwrap_or("");
-        match name {
-            "Bytes" => Some(ParamType::Bytes),
-            "Address" => Some(ParamType::Address),
-            "UtxoRef" => Some(ParamType::UtxoRef),
-            "Utxo" => Some(ParamType::Utxo),
-            "AnyAsset" => Some(ParamType::AnyAsset),
-            _ => None,
-        }
-    }
-
-    /// Interprets one externally-tagged `oneOf` branch into a [`VariantCase`].
-    fn variant_case(case: &Value, components: &HashMap<String, Value>) -> VariantCase {
-        let tag = case
-            .get("required")
-            .and_then(Value::as_array)
-            .and_then(|r| r.first())
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string();
-
-        let fields = case
-            .get("properties")
-            .and_then(Value::as_object)
-            .and_then(|props| props.get(&tag))
-            .map(|fields| Self::from_json_schema(fields, components))
-            .unwrap_or_else(|| ParamType::Unknown(case.clone()));
-
-        VariantCase {
-            tag,
-            fields: Box::new(fields),
-        }
-    }
-
-    /// Creates a parameter type from a JSON schema node.
-    ///
-    /// Interprets every shape `tx3c` can emit (see the SDK spec's
-    /// `api-surface/args.md`). It never fails: an unrecognized shape — including a
-    /// bare `string`, an unresolved object, or an unknown `$ref` — becomes
-    /// [`ParamType::Unknown`] carrying the raw schema.
-    ///
-    /// # Arguments
-    ///
-    /// * `schema` - The JSON schema node to interpret
-    /// * `components` - The TII's `components.schemas` table, used to resolve
-    ///   `#/components/schemas/<Name>` references to user-defined types
-    pub fn from_json_schema(schema: &Value, components: &HashMap<String, Value>) -> ParamType {
-        let Some(obj) = schema.as_object() else {
-            return ParamType::Unknown(schema.clone());
-        };
-
-        if let Some(reference) = obj.get("$ref").and_then(Value::as_str) {
-            if let Some(name) = reference.strip_prefix("#/components/schemas/") {
-                return match components.get(name) {
-                    Some(resolved) => Self::from_json_schema(resolved, components),
-                    None => ParamType::Unknown(schema.clone()),
-                };
-            }
-            return Self::core_ref_type(reference)
-                .unwrap_or_else(|| ParamType::Unknown(schema.clone()));
-        }
-
-        if let Some(cases) = obj.get("oneOf").and_then(Value::as_array) {
-            return ParamType::Variant(
-                cases
-                    .iter()
-                    .map(|case| Self::variant_case(case, components))
-                    .collect(),
-            );
-        }
-
-        match obj.get("type").and_then(Value::as_str) {
-            Some("integer") => ParamType::Integer,
-            Some("boolean") => ParamType::Boolean,
-            Some("null") => ParamType::Unit,
-            Some("array") => {
-                if let Some(prefix) = obj.get("prefixItems").and_then(Value::as_array) {
-                    ParamType::Tuple(
-                        prefix
-                            .iter()
-                            .map(|el| Self::from_json_schema(el, components))
-                            .collect(),
-                    )
-                } else if let Some(items) = obj.get("items").filter(|i| i.is_object()) {
-                    ParamType::List(Box::new(Self::from_json_schema(items, components)))
-                } else {
-                    ParamType::Unknown(schema.clone())
-                }
-            }
-            Some("object") => {
-                if let Some(value) = obj.get("additionalProperties").filter(|v| v.is_object()) {
-                    ParamType::Map(Box::new(Self::from_json_schema(value, components)))
-                } else if let Some(props) = obj.get("properties").and_then(Value::as_object) {
-                    ParamType::Record(
-                        props
-                            .iter()
-                            .map(|(k, v)| (k.clone(), Self::from_json_schema(v, components)))
-                            .collect(),
-                    )
-                } else {
-                    ParamType::Unknown(schema.clone())
-                }
-            }
-            _ => ParamType::Unknown(schema.clone()),
-        }
-    }
-}
-
 /// Input query specification.
 ///
 /// This type is currently a placeholder for future input query functionality.
 pub struct InputQuery {}
-
-/// Map of parameter names to their types.
-///
-/// Used to represent the complete set of parameters required for a transaction.
-pub type ParamMap = HashMap<String, ParamType>;
 
 /// Map of input queries.
 ///
@@ -717,170 +532,43 @@ mod tests {
         dbg!(&tx);
     }
 
-    fn pt(schema: serde_json::Value) -> ParamType {
-        ParamType::from_json_schema(&schema, &HashMap::new())
-    }
-
     #[test]
-    fn maps_primitives_and_unit() {
-        assert!(matches!(pt(json!({"type": "integer"})), ParamType::Integer));
-        assert!(matches!(pt(json!({"type": "boolean"})), ParamType::Boolean));
-        assert!(matches!(pt(json!({"type": "null"})), ParamType::Unit));
-    }
+    fn invoke_interprets_complex_param_types() {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let tii = format!("{manifest_dir}/tests/fixtures/complex.tii");
 
-    #[test]
-    fn maps_core_refs_in_both_url_forms() {
-        for prefix in [
-            "https://tx3.land/specs/v1beta0/tii#/$defs",
-            "https://tx3.land/specs/v1beta0/core#",
-        ] {
-            // the legacy form has no trailing slash before the name; the canonical
-            // form does — the trailing-name matcher handles both.
-            let join = |name: &str| {
-                if prefix.ends_with('#') {
-                    format!("{prefix}{name}")
-                } else {
-                    format!("{prefix}/{name}")
-                }
-            };
-            assert!(matches!(pt(json!({"$ref": join("Bytes")})), ParamType::Bytes));
-            assert!(matches!(
-                pt(json!({"$ref": join("Address")})),
-                ParamType::Address
-            ));
-            assert!(matches!(
-                pt(json!({"$ref": join("UtxoRef")})),
-                ParamType::UtxoRef
-            ));
-            assert!(matches!(pt(json!({"$ref": join("Utxo")})), ParamType::Utxo));
-            assert!(matches!(
-                pt(json!({"$ref": join("AnyAsset")})),
-                ParamType::AnyAsset
-            ));
-        }
-    }
+        let protocol = Protocol::from_file(&tii).unwrap();
+        let mut invoke = protocol.invoke("complex", None).unwrap();
+        let params = invoke.params();
 
-    #[test]
-    fn maps_list_and_nested_list() {
-        match pt(json!({"type": "array", "items": {"type": "integer"}})) {
-            ParamType::List(inner) => assert!(matches!(*inner, ParamType::Integer)),
-            other => panic!("expected list, got {other:?}"),
-        }
-        match pt(json!({"type": "array", "items": {"type": "array", "items": {"type": "boolean"}}})) {
-            ParamType::List(inner) => match *inner {
-                ParamType::List(deep) => assert!(matches!(*deep, ParamType::Boolean)),
-                other => panic!("expected list(list), got {other:?}"),
-            },
-            other => panic!("expected list, got {other:?}"),
-        }
-    }
+        // Primitives, unit, and core `$ref`s.
+        assert!(matches!(params["quantity"], ParamType::Integer));
+        assert!(matches!(params["flag"], ParamType::Boolean));
+        assert!(matches!(params["nothing"], ParamType::Unit));
+        assert!(matches!(params["recipient"], ParamType::Address));
+        assert!(matches!(params["source"], ParamType::UtxoRef));
+        assert!(matches!(params["bag"], ParamType::AnyAsset));
 
-    #[test]
-    fn maps_tuple_with_prefix_items() {
-        let schema = json!({
-            "type": "array",
-            "prefixItems": [
-                {"type": "integer"},
-                {"$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"}
-            ],
-            "items": false
-        });
-        match pt(schema) {
-            ParamType::Tuple(els) => {
-                assert_eq!(els.len(), 2);
-                assert!(matches!(els[0], ParamType::Integer));
-                assert!(matches!(els[1], ParamType::Bytes));
-            }
-            other => panic!("expected tuple, got {other:?}"),
-        }
-    }
+        // Parties become addresses.
+        assert!(matches!(params["sender"], ParamType::Address));
+        assert!(matches!(params["receiver"], ParamType::Address));
 
-    #[test]
-    fn maps_map_via_additional_properties() {
-        match pt(json!({"type": "object", "additionalProperties": {"type": "integer"}})) {
-            ParamType::Map(value) => assert!(matches!(*value, ParamType::Integer)),
-            other => panic!("expected map, got {other:?}"),
-        }
-    }
+        // Compound kinds.
+        assert!(matches!(params["amounts"], ParamType::List(_)));
+        assert!(matches!(params["pair"], ParamType::Tuple(_)));
+        assert!(matches!(params["labels"], ParamType::Map(_)));
 
-    #[test]
-    fn maps_record_via_properties() {
-        let schema = json!({
-            "type": "object",
-            "properties": {"price": {"type": "integer"}, "live": {"type": "boolean"}},
-            "required": ["price", "live"]
-        });
-        match pt(schema) {
-            ParamType::Record(fields) => {
-                assert!(matches!(fields["price"], ParamType::Integer));
-                assert!(matches!(fields["live"], ParamType::Boolean));
-            }
-            other => panic!("expected record, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn maps_variant_via_one_of() {
-        let schema = json!({
-            "oneOf": [
-                {"type": "object", "additionalProperties": false, "required": ["Buy"],
-                 "properties": {"Buy": {"type": "object", "properties": {}, "required": []}}},
-                {"type": "object", "additionalProperties": false, "required": ["Sell"],
-                 "properties": {"Sell": {"type": "object", "properties": {"price": {"type": "integer"}}, "required": ["price"]}}}
-            ]
-        });
-        match pt(schema) {
-            ParamType::Variant(cases) => {
-                assert_eq!(cases.len(), 2);
-                assert_eq!(cases[0].tag, "Buy");
-                assert_eq!(cases[1].tag, "Sell");
-                match &*cases[1].fields {
-                    ParamType::Record(fields) => {
-                        assert!(matches!(fields["price"], ParamType::Integer))
-                    }
-                    other => panic!("expected record fields, got {other:?}"),
-                }
-            }
-            other => panic!("expected variant, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn resolves_component_refs_recursively() {
-        let mut components = HashMap::new();
-        components.insert(
-            "AssetClass".to_string(),
-            json!({
-                "type": "object",
-                "properties": {"policy": {"$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"}},
-                "required": ["policy"]
-            }),
-        );
-        let schema = json!({"$ref": "#/components/schemas/AssetClass"});
-        match ParamType::from_json_schema(&schema, &components) {
+        // `#/components/schemas/<Name>` refs resolve against the components table:
+        // a record (AssetClass) and a variant (Side). This exercises the
+        // `components` threading through `Protocol::invoke`.
+        match &params["asset"] {
             ParamType::Record(fields) => assert!(matches!(fields["policy"], ParamType::Bytes)),
-            other => panic!("expected record, got {other:?}"),
+            other => panic!("expected asset record, got {other:?}"),
         }
-        // Missing component → Unknown, never panics.
-        let missing = json!({"$ref": "#/components/schemas/Nope"});
-        assert!(matches!(
-            ParamType::from_json_schema(&missing, &components),
-            ParamType::Unknown(_)
-        ));
-    }
-
-    #[test]
-    fn unrecognized_shapes_fall_back_to_unknown() {
-        assert!(matches!(pt(json!({"type": "string"})), ParamType::Unknown(_)));
-        assert!(matches!(pt(json!({})), ParamType::Unknown(_)));
-        assert!(matches!(pt(json!("nonsense")), ParamType::Unknown(_)));
-        assert!(matches!(
-            pt(json!({"$ref": "https://example.com/Weird"})),
-            ParamType::Unknown(_)
-        ));
-        assert!(matches!(
-            pt(json!({"type": "array"})),
-            ParamType::Unknown(_)
-        ));
+        match &params["side"] {
+            ParamType::Variant(cases) => assert!(!cases.is_empty()),
+            other => panic!("expected side variant, got {other:?}"),
+        }
     }
 }
+

--- a/sdk/src/tii/mod.rs
+++ b/sdk/src/tii/mod.rs
@@ -64,9 +64,8 @@
 //! for different networks. When invoking a transaction with a profile, those values are
 //! automatically populated.
 
-use schemars::schema::{InstanceType, Schema, SingleOrVec};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap};
 use thiserror::Error;
 
@@ -108,18 +107,20 @@ pub enum Error {
     InvalidParamType,
 }
 
-fn params_from_schema(schema: Schema) -> Result<ParamMap, Error> {
+/// Builds a parameter-type map from a JSON schema's `properties`. Never fails:
+/// unrecognized property schemas yield [`ParamType::Unknown`]. `components` is the
+/// TII's `components.schemas` table, used to resolve `#/components/schemas/<Name>`
+/// refs to user-defined record / variant types.
+fn params_from_schema(schema: &Value, components: &HashMap<String, Value>) -> ParamMap {
     let mut params = ParamMap::new();
 
-    let as_object = schema.into_object();
-
-    if let Some(obj_validation) = as_object.object {
-        for (key, value) in obj_validation.properties {
-            params.insert(key, ParamType::from_json_schema(value)?);
+    if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+        for (key, value) in properties {
+            params.insert(key.clone(), ParamType::from_json_schema(value, components));
         }
     }
 
-    Ok(params)
+    params
 }
 
 /// A TX3 protocol loaded from a TII file.
@@ -291,15 +292,22 @@ impl Protocol {
             args: ArgMap::new(),
         };
 
+        let components: HashMap<String, Value> = self
+            .spec
+            .components
+            .as_ref()
+            .map(|c| c.schemas.clone())
+            .unwrap_or_default();
+
         for party in self.spec.parties.keys() {
             out.params.insert(party.to_lowercase(), ParamType::Address);
         }
 
         if let Some(env) = &self.spec.environment {
-            out.params.extend(params_from_schema(env.clone())?);
+            out.params.extend(params_from_schema(env, &components));
         }
 
-        out.params.extend(params_from_schema(tx.params.clone())?);
+        out.params.extend(params_from_schema(&tx.params, &components));
 
         if let Some(profile) = profile {
             if let Some(env) = profile.environment.as_object() {
@@ -349,7 +357,9 @@ impl Protocol {
 /// Type of a transaction parameter.
 ///
 /// This enum represents the various types that transaction parameters can have,
-/// including primitives, complex types, and references to TX3 core types.
+/// including primitives, compound types, and references to TX3 core types. It is
+/// built from the TII params JSON schema by [`ParamType::from_json_schema`], which
+/// never fails — any shape it does not recognize becomes [`ParamType::Unknown`].
 #[derive(Debug, Clone)]
 pub enum ParamType {
     /// Byte array type (hex-encoded).
@@ -358,62 +368,148 @@ pub enum ParamType {
     Integer,
     /// Boolean type.
     Boolean,
+    /// Unit type (`{ "type": "null" }`).
+    Unit,
     /// UTXO reference in format `0x[64hex]#[index]`.
     UtxoRef,
     /// Bech32-encoded blockchain address.
     Address,
-    /// List of another parameter type.
+    /// A resolved UTxO object.
+    Utxo,
+    /// An asset identified at runtime by policy and name.
+    AnyAsset,
+    /// Homogeneous, variable-length sequence (`array` + `items`).
     List(Box<ParamType>),
-    /// Custom JSON schema type.
-    Custom(Schema),
+    /// Fixed-length, positionally-typed sequence (`array` + `prefixItems`).
+    Tuple(Vec<ParamType>),
+    /// String-keyed homogeneous map (`object` + `additionalProperties`).
+    Map(Box<ParamType>),
+    /// User-defined record (`object` + `properties`), field name → type.
+    Record(BTreeMap<String, ParamType>),
+    /// User-defined tagged union (`oneOf`), externally tagged.
+    Variant(Vec<VariantCase>),
+    /// A schema shape that could not be interpreted; carries the raw schema.
+    Unknown(Value),
+}
+
+/// One case of a [`ParamType::Variant`].
+#[derive(Debug, Clone)]
+pub struct VariantCase {
+    /// The case tag (the single `required` key of the externally-tagged object).
+    pub tag: String,
+    /// The case payload (typically a [`ParamType::Record`]).
+    pub fields: Box<ParamType>,
 }
 
 impl ParamType {
-    fn from_json_type(instance_type: InstanceType) -> Result<ParamType, Error> {
-        match instance_type {
-            InstanceType::Integer => Ok(ParamType::Integer),
-            InstanceType::Boolean => Ok(ParamType::Boolean),
-            _ => Err(Error::InvalidParamType),
+    /// Maps a built-in core `$ref` to its kind by trailing name, so both the
+    /// canonical `…/tii#/$defs/<Name>` and legacy `…/core#<Name>` forms resolve.
+    fn core_ref_type(reference: &str) -> Option<ParamType> {
+        let name = reference.rsplit(['#', '/']).next().unwrap_or("");
+        match name {
+            "Bytes" => Some(ParamType::Bytes),
+            "Address" => Some(ParamType::Address),
+            "UtxoRef" => Some(ParamType::UtxoRef),
+            "Utxo" => Some(ParamType::Utxo),
+            "AnyAsset" => Some(ParamType::AnyAsset),
+            _ => None,
         }
     }
 
-    /// Creates a parameter type from a JSON schema.
+    /// Interprets one externally-tagged `oneOf` branch into a [`VariantCase`].
+    fn variant_case(case: &Value, components: &HashMap<String, Value>) -> VariantCase {
+        let tag = case
+            .get("required")
+            .and_then(Value::as_array)
+            .and_then(|r| r.first())
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        let fields = case
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|props| props.get(&tag))
+            .map(|fields| Self::from_json_schema(fields, components))
+            .unwrap_or_else(|| ParamType::Unknown(case.clone()));
+
+        VariantCase {
+            tag,
+            fields: Box::new(fields),
+        }
+    }
+
+    /// Creates a parameter type from a JSON schema node.
     ///
-    /// This method interprets a JSON schema and converts it to the appropriate
-    /// `ParamType`. It handles TX3 core type references (Bytes, Address, UtxoRef)
-    /// as well as primitive types.
+    /// Interprets every shape `tx3c` can emit (see the SDK spec's
+    /// `api-surface/args.md`). It never fails: an unrecognized shape — including a
+    /// bare `string`, an unresolved object, or an unknown `$ref` — becomes
+    /// [`ParamType::Unknown`] carrying the raw schema.
     ///
     /// # Arguments
     ///
-    /// * `schema` - The JSON schema to convert
-    ///
-    /// # Returns
-    ///
-    /// Returns the corresponding `ParamType` on success.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the schema cannot be mapped to a known parameter type.
-    pub fn from_json_schema(schema: Schema) -> Result<ParamType, Error> {
-        let as_object = schema.into_object();
+    /// * `schema` - The JSON schema node to interpret
+    /// * `components` - The TII's `components.schemas` table, used to resolve
+    ///   `#/components/schemas/<Name>` references to user-defined types
+    pub fn from_json_schema(schema: &Value, components: &HashMap<String, Value>) -> ParamType {
+        let Some(obj) = schema.as_object() else {
+            return ParamType::Unknown(schema.clone());
+        };
 
-        if let Some(reference) = &as_object.reference {
-            return match reference.as_str() {
-                "https://tx3.land/specs/v1beta0/core#Bytes" => Ok(ParamType::Bytes),
-                "https://tx3.land/specs/v1beta0/core#Address" => Ok(ParamType::Address),
-                "https://tx3.land/specs/v1beta0/core#UtxoRef" => Ok(ParamType::UtxoRef),
-                _ => Err(Error::InvalidParamType),
-            };
+        if let Some(reference) = obj.get("$ref").and_then(Value::as_str) {
+            if let Some(name) = reference.strip_prefix("#/components/schemas/") {
+                return match components.get(name) {
+                    Some(resolved) => Self::from_json_schema(resolved, components),
+                    None => ParamType::Unknown(schema.clone()),
+                };
+            }
+            return Self::core_ref_type(reference)
+                .unwrap_or_else(|| ParamType::Unknown(schema.clone()));
         }
 
-        if let Some(inner) = as_object.instance_type {
-            return match inner {
-                SingleOrVec::Single(x) => Self::from_json_type(*x),
-                SingleOrVec::Vec(_) => Err(Error::InvalidParamType),
-            };
+        if let Some(cases) = obj.get("oneOf").and_then(Value::as_array) {
+            return ParamType::Variant(
+                cases
+                    .iter()
+                    .map(|case| Self::variant_case(case, components))
+                    .collect(),
+            );
         }
 
-        Err(Error::InvalidParamType)
+        match obj.get("type").and_then(Value::as_str) {
+            Some("integer") => ParamType::Integer,
+            Some("boolean") => ParamType::Boolean,
+            Some("null") => ParamType::Unit,
+            Some("array") => {
+                if let Some(prefix) = obj.get("prefixItems").and_then(Value::as_array) {
+                    ParamType::Tuple(
+                        prefix
+                            .iter()
+                            .map(|el| Self::from_json_schema(el, components))
+                            .collect(),
+                    )
+                } else if let Some(items) = obj.get("items").filter(|i| i.is_object()) {
+                    ParamType::List(Box::new(Self::from_json_schema(items, components)))
+                } else {
+                    ParamType::Unknown(schema.clone())
+                }
+            }
+            Some("object") => {
+                if let Some(value) = obj.get("additionalProperties").filter(|v| v.is_object()) {
+                    ParamType::Map(Box::new(Self::from_json_schema(value, components)))
+                } else if let Some(props) = obj.get("properties").and_then(Value::as_object) {
+                    ParamType::Record(
+                        props
+                            .iter()
+                            .map(|(k, v)| (k.clone(), Self::from_json_schema(v, components)))
+                            .collect(),
+                    )
+                } else {
+                    ParamType::Unknown(schema.clone())
+                }
+            }
+            _ => ParamType::Unknown(schema.clone()),
+        }
     }
 }
 
@@ -619,5 +715,172 @@ mod tests {
         let tx = invoke.into_resolve_request().unwrap();
 
         dbg!(&tx);
+    }
+
+    fn pt(schema: serde_json::Value) -> ParamType {
+        ParamType::from_json_schema(&schema, &HashMap::new())
+    }
+
+    #[test]
+    fn maps_primitives_and_unit() {
+        assert!(matches!(pt(json!({"type": "integer"})), ParamType::Integer));
+        assert!(matches!(pt(json!({"type": "boolean"})), ParamType::Boolean));
+        assert!(matches!(pt(json!({"type": "null"})), ParamType::Unit));
+    }
+
+    #[test]
+    fn maps_core_refs_in_both_url_forms() {
+        for prefix in [
+            "https://tx3.land/specs/v1beta0/tii#/$defs",
+            "https://tx3.land/specs/v1beta0/core#",
+        ] {
+            // the legacy form has no trailing slash before the name; the canonical
+            // form does — the trailing-name matcher handles both.
+            let join = |name: &str| {
+                if prefix.ends_with('#') {
+                    format!("{prefix}{name}")
+                } else {
+                    format!("{prefix}/{name}")
+                }
+            };
+            assert!(matches!(pt(json!({"$ref": join("Bytes")})), ParamType::Bytes));
+            assert!(matches!(
+                pt(json!({"$ref": join("Address")})),
+                ParamType::Address
+            ));
+            assert!(matches!(
+                pt(json!({"$ref": join("UtxoRef")})),
+                ParamType::UtxoRef
+            ));
+            assert!(matches!(pt(json!({"$ref": join("Utxo")})), ParamType::Utxo));
+            assert!(matches!(
+                pt(json!({"$ref": join("AnyAsset")})),
+                ParamType::AnyAsset
+            ));
+        }
+    }
+
+    #[test]
+    fn maps_list_and_nested_list() {
+        match pt(json!({"type": "array", "items": {"type": "integer"}})) {
+            ParamType::List(inner) => assert!(matches!(*inner, ParamType::Integer)),
+            other => panic!("expected list, got {other:?}"),
+        }
+        match pt(json!({"type": "array", "items": {"type": "array", "items": {"type": "boolean"}}})) {
+            ParamType::List(inner) => match *inner {
+                ParamType::List(deep) => assert!(matches!(*deep, ParamType::Boolean)),
+                other => panic!("expected list(list), got {other:?}"),
+            },
+            other => panic!("expected list, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_tuple_with_prefix_items() {
+        let schema = json!({
+            "type": "array",
+            "prefixItems": [
+                {"type": "integer"},
+                {"$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"}
+            ],
+            "items": false
+        });
+        match pt(schema) {
+            ParamType::Tuple(els) => {
+                assert_eq!(els.len(), 2);
+                assert!(matches!(els[0], ParamType::Integer));
+                assert!(matches!(els[1], ParamType::Bytes));
+            }
+            other => panic!("expected tuple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_map_via_additional_properties() {
+        match pt(json!({"type": "object", "additionalProperties": {"type": "integer"}})) {
+            ParamType::Map(value) => assert!(matches!(*value, ParamType::Integer)),
+            other => panic!("expected map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_record_via_properties() {
+        let schema = json!({
+            "type": "object",
+            "properties": {"price": {"type": "integer"}, "live": {"type": "boolean"}},
+            "required": ["price", "live"]
+        });
+        match pt(schema) {
+            ParamType::Record(fields) => {
+                assert!(matches!(fields["price"], ParamType::Integer));
+                assert!(matches!(fields["live"], ParamType::Boolean));
+            }
+            other => panic!("expected record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_variant_via_one_of() {
+        let schema = json!({
+            "oneOf": [
+                {"type": "object", "additionalProperties": false, "required": ["Buy"],
+                 "properties": {"Buy": {"type": "object", "properties": {}, "required": []}}},
+                {"type": "object", "additionalProperties": false, "required": ["Sell"],
+                 "properties": {"Sell": {"type": "object", "properties": {"price": {"type": "integer"}}, "required": ["price"]}}}
+            ]
+        });
+        match pt(schema) {
+            ParamType::Variant(cases) => {
+                assert_eq!(cases.len(), 2);
+                assert_eq!(cases[0].tag, "Buy");
+                assert_eq!(cases[1].tag, "Sell");
+                match &*cases[1].fields {
+                    ParamType::Record(fields) => {
+                        assert!(matches!(fields["price"], ParamType::Integer))
+                    }
+                    other => panic!("expected record fields, got {other:?}"),
+                }
+            }
+            other => panic!("expected variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_component_refs_recursively() {
+        let mut components = HashMap::new();
+        components.insert(
+            "AssetClass".to_string(),
+            json!({
+                "type": "object",
+                "properties": {"policy": {"$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"}},
+                "required": ["policy"]
+            }),
+        );
+        let schema = json!({"$ref": "#/components/schemas/AssetClass"});
+        match ParamType::from_json_schema(&schema, &components) {
+            ParamType::Record(fields) => assert!(matches!(fields["policy"], ParamType::Bytes)),
+            other => panic!("expected record, got {other:?}"),
+        }
+        // Missing component → Unknown, never panics.
+        let missing = json!({"$ref": "#/components/schemas/Nope"});
+        assert!(matches!(
+            ParamType::from_json_schema(&missing, &components),
+            ParamType::Unknown(_)
+        ));
+    }
+
+    #[test]
+    fn unrecognized_shapes_fall_back_to_unknown() {
+        assert!(matches!(pt(json!({"type": "string"})), ParamType::Unknown(_)));
+        assert!(matches!(pt(json!({})), ParamType::Unknown(_)));
+        assert!(matches!(pt(json!("nonsense")), ParamType::Unknown(_)));
+        assert!(matches!(
+            pt(json!({"$ref": "https://example.com/Weird"})),
+            ParamType::Unknown(_)
+        ));
+        assert!(matches!(
+            pt(json!({"type": "array"})),
+            ParamType::Unknown(_)
+        ));
     }
 }

--- a/sdk/src/tii/schema.rs
+++ b/sdk/src/tii/schema.rs
@@ -1,0 +1,383 @@
+//! Interpretation of the TII params JSON schema into [`ParamType`] kinds.
+//!
+//! A TII embeds, for each transaction, a JSON schema describing its parameters
+//! (and an optional environment schema). This module turns those schema nodes —
+//! every shape `tx3c` can emit, see the SDK spec's `api-surface/args.md` — into
+//! the [`ParamType`] model the rest of the SDK works with. Interpretation never
+//! fails: any shape it does not recognize becomes [`ParamType::Unknown`].
+
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
+
+/// Map of parameter names to their types.
+///
+/// Used to represent the complete set of parameters required for a transaction.
+pub type ParamMap = HashMap<String, ParamType>;
+
+/// Builds a parameter-type map from a JSON schema's `properties`. Never fails:
+/// unrecognized property schemas yield [`ParamType::Unknown`]. `components` is the
+/// TII's `components.schemas` table, used to resolve `#/components/schemas/<Name>`
+/// refs to user-defined record / variant types.
+pub(super) fn params_from_schema(schema: &Value, components: &HashMap<String, Value>) -> ParamMap {
+    let mut params = ParamMap::new();
+
+    if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+        for (key, value) in properties {
+            params.insert(key.clone(), ParamType::from_json_schema(value, components));
+        }
+    }
+
+    params
+}
+
+/// Type of a transaction parameter.
+///
+/// This enum represents the various types that transaction parameters can have,
+/// including primitives, compound types, and references to TX3 core types. It is
+/// built from the TII params JSON schema by [`ParamType::from_json_schema`], which
+/// never fails — any shape it does not recognize becomes [`ParamType::Unknown`].
+#[derive(Debug, Clone)]
+pub enum ParamType {
+    /// Byte array type (hex-encoded).
+    Bytes,
+    /// Integer type (signed or unsigned).
+    Integer,
+    /// Boolean type.
+    Boolean,
+    /// Unit type (`{ "type": "null" }`).
+    Unit,
+    /// UTXO reference in format `0x[64hex]#[index]`.
+    UtxoRef,
+    /// Bech32-encoded blockchain address.
+    Address,
+    /// A resolved UTxO object.
+    Utxo,
+    /// An asset identified at runtime by policy and name.
+    AnyAsset,
+    /// Homogeneous, variable-length sequence (`array` + `items`).
+    List(Box<ParamType>),
+    /// Fixed-length, positionally-typed sequence (`array` + `prefixItems`).
+    Tuple(Vec<ParamType>),
+    /// String-keyed homogeneous map (`object` + `additionalProperties`).
+    Map(Box<ParamType>),
+    /// User-defined record (`object` + `properties`), field name → type.
+    Record(BTreeMap<String, ParamType>),
+    /// User-defined tagged union (`oneOf`), externally tagged.
+    Variant(Vec<VariantCase>),
+    /// A schema shape that could not be interpreted; carries the raw schema.
+    Unknown(Value),
+}
+
+/// One case of a [`ParamType::Variant`].
+#[derive(Debug, Clone)]
+pub struct VariantCase {
+    /// The case tag (the single `required` key of the externally-tagged object).
+    pub tag: String,
+    /// The case payload (typically a [`ParamType::Record`]).
+    pub fields: Box<ParamType>,
+}
+
+impl ParamType {
+    /// Maps a built-in core `$ref` to its kind by trailing name, so both the
+    /// canonical `…/tii#/$defs/<Name>` and legacy `…/core#<Name>` forms resolve.
+    fn core_ref_type(reference: &str) -> Option<ParamType> {
+        let name = reference.rsplit(['#', '/']).next().unwrap_or("");
+        match name {
+            "Bytes" => Some(ParamType::Bytes),
+            "Address" => Some(ParamType::Address),
+            "UtxoRef" => Some(ParamType::UtxoRef),
+            "Utxo" => Some(ParamType::Utxo),
+            "AnyAsset" => Some(ParamType::AnyAsset),
+            _ => None,
+        }
+    }
+
+    /// Resolves a `$ref` node: `#/components/schemas/<Name>` against the TII's
+    /// `components` table (recursing into the resolved schema), otherwise a
+    /// built-in core ref. An unresolved ref becomes [`ParamType::Unknown`].
+    fn ref_type(schema: &Value, reference: &str, components: &HashMap<String, Value>) -> ParamType {
+        if let Some(name) = reference.strip_prefix("#/components/schemas/") {
+            return match components.get(name) {
+                Some(resolved) => Self::from_json_schema(resolved, components),
+                None => ParamType::Unknown(schema.clone()),
+            };
+        }
+
+        Self::core_ref_type(reference).unwrap_or_else(|| ParamType::Unknown(schema.clone()))
+    }
+
+    /// Maps a `oneOf` array to a [`ParamType::Variant`] of externally-tagged cases.
+    fn variant_type(cases: &[Value], components: &HashMap<String, Value>) -> ParamType {
+        ParamType::Variant(
+            cases
+                .iter()
+                .map(|case| Self::variant_case(case, components))
+                .collect(),
+        )
+    }
+
+    /// Interprets one externally-tagged `oneOf` branch into a [`VariantCase`].
+    fn variant_case(case: &Value, components: &HashMap<String, Value>) -> VariantCase {
+        let tag = case
+            .get("required")
+            .and_then(Value::as_array)
+            .and_then(|r| r.first())
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        let fields = case
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|props| props.get(&tag))
+            .map(|fields| Self::from_json_schema(fields, components))
+            .unwrap_or_else(|| ParamType::Unknown(case.clone()));
+
+        VariantCase {
+            tag,
+            fields: Box::new(fields),
+        }
+    }
+
+    /// Maps an `array` schema: `prefixItems` → [`ParamType::Tuple`], `items` →
+    /// [`ParamType::List`]. An array carrying neither becomes [`ParamType::Unknown`].
+    fn array_type(schema: &Value, components: &HashMap<String, Value>) -> ParamType {
+        if let Some(prefix) = schema.get("prefixItems").and_then(Value::as_array) {
+            ParamType::Tuple(
+                prefix
+                    .iter()
+                    .map(|el| Self::from_json_schema(el, components))
+                    .collect(),
+            )
+        } else if let Some(items) = schema.get("items").filter(|i| i.is_object()) {
+            ParamType::List(Box::new(Self::from_json_schema(items, components)))
+        } else {
+            ParamType::Unknown(schema.clone())
+        }
+    }
+
+    /// Maps an `object` schema: `additionalProperties` → [`ParamType::Map`],
+    /// `properties` → [`ParamType::Record`]. Neither present → [`ParamType::Unknown`].
+    fn object_type(schema: &Value, components: &HashMap<String, Value>) -> ParamType {
+        if let Some(value) = schema.get("additionalProperties").filter(|v| v.is_object()) {
+            ParamType::Map(Box::new(Self::from_json_schema(value, components)))
+        } else if let Some(props) = schema.get("properties").and_then(Value::as_object) {
+            ParamType::Record(
+                props
+                    .iter()
+                    .map(|(k, v)| (k.clone(), Self::from_json_schema(v, components)))
+                    .collect(),
+            )
+        } else {
+            ParamType::Unknown(schema.clone())
+        }
+    }
+
+    /// Creates a parameter type from a JSON schema node.
+    ///
+    /// Interprets every shape `tx3c` can emit (see the SDK spec's
+    /// `api-surface/args.md`). It never fails: an unrecognized shape — including a
+    /// bare `string`, an unresolved object, or an unknown `$ref` — becomes
+    /// [`ParamType::Unknown`] carrying the raw schema.
+    ///
+    /// # Arguments
+    ///
+    /// * `schema` - The JSON schema node to interpret
+    /// * `components` - The TII's `components.schemas` table, used to resolve
+    ///   `#/components/schemas/<Name>` references to user-defined types
+    pub fn from_json_schema(schema: &Value, components: &HashMap<String, Value>) -> ParamType {
+        let Some(obj) = schema.as_object() else {
+            return ParamType::Unknown(schema.clone());
+        };
+
+        if let Some(reference) = obj.get("$ref").and_then(Value::as_str) {
+            return Self::ref_type(schema, reference, components);
+        }
+
+        if let Some(cases) = obj.get("oneOf").and_then(Value::as_array) {
+            return Self::variant_type(cases, components);
+        }
+
+        match obj.get("type").and_then(Value::as_str) {
+            Some("integer") => ParamType::Integer,
+            Some("boolean") => ParamType::Boolean,
+            Some("null") => ParamType::Unit,
+            Some("array") => Self::array_type(schema, components),
+            Some("object") => Self::object_type(schema, components),
+            _ => ParamType::Unknown(schema.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn pt(schema: serde_json::Value) -> ParamType {
+        ParamType::from_json_schema(&schema, &HashMap::new())
+    }
+
+    #[test]
+    fn maps_primitives_and_unit() {
+        assert!(matches!(pt(json!({"type": "integer"})), ParamType::Integer));
+        assert!(matches!(pt(json!({"type": "boolean"})), ParamType::Boolean));
+        assert!(matches!(pt(json!({"type": "null"})), ParamType::Unit));
+    }
+
+    #[test]
+    fn maps_core_refs_in_both_url_forms() {
+        for prefix in [
+            "https://tx3.land/specs/v1beta0/tii#/$defs",
+            "https://tx3.land/specs/v1beta0/core#",
+        ] {
+            // the legacy form has no trailing slash before the name; the canonical
+            // form does — the trailing-name matcher handles both.
+            let join = |name: &str| {
+                if prefix.ends_with('#') {
+                    format!("{prefix}{name}")
+                } else {
+                    format!("{prefix}/{name}")
+                }
+            };
+            assert!(matches!(pt(json!({"$ref": join("Bytes")})), ParamType::Bytes));
+            assert!(matches!(
+                pt(json!({"$ref": join("Address")})),
+                ParamType::Address
+            ));
+            assert!(matches!(
+                pt(json!({"$ref": join("UtxoRef")})),
+                ParamType::UtxoRef
+            ));
+            assert!(matches!(pt(json!({"$ref": join("Utxo")})), ParamType::Utxo));
+            assert!(matches!(
+                pt(json!({"$ref": join("AnyAsset")})),
+                ParamType::AnyAsset
+            ));
+        }
+    }
+
+    #[test]
+    fn maps_list_and_nested_list() {
+        match pt(json!({"type": "array", "items": {"type": "integer"}})) {
+            ParamType::List(inner) => assert!(matches!(*inner, ParamType::Integer)),
+            other => panic!("expected list, got {other:?}"),
+        }
+        match pt(json!({"type": "array", "items": {"type": "array", "items": {"type": "boolean"}}})) {
+            ParamType::List(inner) => match *inner {
+                ParamType::List(deep) => assert!(matches!(*deep, ParamType::Boolean)),
+                other => panic!("expected list(list), got {other:?}"),
+            },
+            other => panic!("expected list, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_tuple_with_prefix_items() {
+        let schema = json!({
+            "type": "array",
+            "prefixItems": [
+                {"type": "integer"},
+                {"$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"}
+            ],
+            "items": false
+        });
+        match pt(schema) {
+            ParamType::Tuple(els) => {
+                assert_eq!(els.len(), 2);
+                assert!(matches!(els[0], ParamType::Integer));
+                assert!(matches!(els[1], ParamType::Bytes));
+            }
+            other => panic!("expected tuple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_map_via_additional_properties() {
+        match pt(json!({"type": "object", "additionalProperties": {"type": "integer"}})) {
+            ParamType::Map(value) => assert!(matches!(*value, ParamType::Integer)),
+            other => panic!("expected map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_record_via_properties() {
+        let schema = json!({
+            "type": "object",
+            "properties": {"price": {"type": "integer"}, "live": {"type": "boolean"}},
+            "required": ["price", "live"]
+        });
+        match pt(schema) {
+            ParamType::Record(fields) => {
+                assert!(matches!(fields["price"], ParamType::Integer));
+                assert!(matches!(fields["live"], ParamType::Boolean));
+            }
+            other => panic!("expected record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_variant_via_one_of() {
+        let schema = json!({
+            "oneOf": [
+                {"type": "object", "additionalProperties": false, "required": ["Buy"],
+                 "properties": {"Buy": {"type": "object", "properties": {}, "required": []}}},
+                {"type": "object", "additionalProperties": false, "required": ["Sell"],
+                 "properties": {"Sell": {"type": "object", "properties": {"price": {"type": "integer"}}, "required": ["price"]}}}
+            ]
+        });
+        match pt(schema) {
+            ParamType::Variant(cases) => {
+                assert_eq!(cases.len(), 2);
+                assert_eq!(cases[0].tag, "Buy");
+                assert_eq!(cases[1].tag, "Sell");
+                match &*cases[1].fields {
+                    ParamType::Record(fields) => {
+                        assert!(matches!(fields["price"], ParamType::Integer))
+                    }
+                    other => panic!("expected record fields, got {other:?}"),
+                }
+            }
+            other => panic!("expected variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_component_refs_recursively() {
+        let mut components = HashMap::new();
+        components.insert(
+            "AssetClass".to_string(),
+            json!({
+                "type": "object",
+                "properties": {"policy": {"$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"}},
+                "required": ["policy"]
+            }),
+        );
+        let schema = json!({"$ref": "#/components/schemas/AssetClass"});
+        match ParamType::from_json_schema(&schema, &components) {
+            ParamType::Record(fields) => assert!(matches!(fields["policy"], ParamType::Bytes)),
+            other => panic!("expected record, got {other:?}"),
+        }
+        // Missing component → Unknown, never panics.
+        let missing = json!({"$ref": "#/components/schemas/Nope"});
+        assert!(matches!(
+            ParamType::from_json_schema(&missing, &components),
+            ParamType::Unknown(_)
+        ));
+    }
+
+    #[test]
+    fn unrecognized_shapes_fall_back_to_unknown() {
+        assert!(matches!(pt(json!({"type": "string"})), ParamType::Unknown(_)));
+        assert!(matches!(pt(json!({})), ParamType::Unknown(_)));
+        assert!(matches!(pt(json!("nonsense")), ParamType::Unknown(_)));
+        assert!(matches!(
+            pt(json!({"$ref": "https://example.com/Weird"})),
+            ParamType::Unknown(_)
+        ));
+        assert!(matches!(
+            pt(json!({"type": "array"})),
+            ParamType::Unknown(_)
+        ));
+    }
+}

--- a/sdk/src/tii/spec.rs
+++ b/sdk/src/tii/spec.rs
@@ -1,5 +1,5 @@
-use schemars::schema::Schema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::core::TirEnvelope;
@@ -18,7 +18,7 @@ pub struct TiiFile {
 
     /// Optional JSON schema for environment parameters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub environment: Option<Schema>,
+    pub environment: Option<Value>,
 
     /// Map of party names to their definitions.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -75,7 +75,7 @@ pub struct Transaction {
     pub tir: TirEnvelope,
 
     /// JSON schema defining the transaction parameters.
-    pub params: Schema,
+    pub params: Value,
 
     /// Optional transaction description.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -119,5 +119,5 @@ pub struct Profile {
 pub struct Components {
     /// Map of reusable JSON schemas.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub schemas: HashMap<String, Schema>,
+    pub schemas: HashMap<String, Value>,
 }

--- a/sdk/tests/fixtures/complex.tii
+++ b/sdk/tests/fixtures/complex.tii
@@ -1,0 +1,119 @@
+{
+  "tii": {
+    "version": "v1beta0"
+  },
+  "protocol": {
+    "name": "complex-types",
+    "scope": "unknown",
+    "version": "0.0.1",
+    "description": "Schema-only fixture exercising every ParamType kind. The TIR envelope is a non-resolvable placeholder; this vector is for parameter-type interpretation tests, not TRP resolution."
+  },
+  "environment": {
+    "type": "object",
+    "properties": {
+      "fee": {
+        "type": "integer"
+      }
+    },
+    "required": ["fee"]
+  },
+  "parties": {
+    "sender": {},
+    "receiver": {}
+  },
+  "profiles": {
+    "local": {
+      "environment": {},
+      "parties": {}
+    }
+  },
+  "components": {
+    "schemas": {
+      "AssetClass": {
+        "type": "object",
+        "properties": {
+          "policy": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" },
+          "name": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }
+        },
+        "required": ["policy", "name"]
+      },
+      "Side": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["Buy"],
+            "properties": {
+              "Buy": { "type": "object", "properties": {}, "required": [] }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["Sell"],
+            "properties": {
+              "Sell": {
+                "type": "object",
+                "properties": { "price": { "type": "integer" } },
+                "required": ["price"]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "transactions": {
+    "complex": {
+      "params": {
+        "type": "object",
+        "properties": {
+          "quantity": { "type": "integer" },
+          "flag": { "type": "boolean" },
+          "nothing": { "type": "null" },
+          "recipient": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Address" },
+          "source": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/UtxoRef" },
+          "bag": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/AnyAsset" },
+          "amounts": {
+            "type": "array",
+            "items": { "type": "integer" }
+          },
+          "pair": {
+            "type": "array",
+            "prefixItems": [
+              { "type": "integer" },
+              { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }
+            ],
+            "items": false,
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": { "type": "integer" }
+          },
+          "asset": { "$ref": "#/components/schemas/AssetClass" },
+          "side": { "$ref": "#/components/schemas/Side" }
+        },
+        "required": [
+          "quantity",
+          "flag",
+          "nothing",
+          "recipient",
+          "source",
+          "bag",
+          "amounts",
+          "pair",
+          "labels",
+          "asset",
+          "side"
+        ]
+      },
+      "tir": {
+        "content": "00",
+        "encoding": "hex",
+        "version": "v1beta0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Reworks `ParamType` to interpret every shape `tx3c` emits into the TII params schema, per the canonical model in the SDK spec's `api-surface/args.md`. This is the rust-sdk slice of a cross-fleet complex-type parity effort (rust/go/python/web).

This SDK was the most broken: `from_json_schema` matched only the exact legacy `…/core#<Name>` URIs and handled only integer/boolean, so it threw `InvalidParamType` on **almost any typed param from a modern TII** (Bytes/Address/UtxoRef are now emitted as `…/tii#/$defs/<Name>` refs), and on every list/tuple/map/object/oneOf.

## Changes

- **Trailing-name `$ref` matching** across both `tii#/$defs/` and legacy `core#` forms; adds `Utxo` and `AnyAsset`.
- New distinct kinds **`Unit` / `List` / `Tuple` / `Map` / `Record` / `Variant`** carrying element/field types, plus an **`Unknown`** fallback.
- **Never throws** — unrecognized shapes (bare `string`, unresolved object, unknown `$ref`) become `Unknown` carrying the raw schema.
- Resolves **`#/components/schemas/<Name>`** refs against the TII components table (threaded from `Protocol::invoke`).
- **Drops `schemars`** in favor of parsing `serde_json::Value` directly — schemars 0.8 cannot represent `prefixItems`, and `Value` unifies this module with the other SDKs and with how `tx3c` builds the schema.

## Tests

`cargo test -p tx3-sdk` — 16 pass (9 new `from_json_schema` cases over the full canonical table, incl. both ref forms, nested compounds, component resolution, and never-throw fallbacks). `cargo clippy` clean; full workspace builds.

Validated against the shared fixture `sdk-spec/test-vectors/complex-types/complex.tii` (cross-checked identical kind map vs the go loader).

## Breaking change

`ParamType` gains variants; `from_json_schema` is now `(&Value, &HashMap<String, Value>) -> ParamType` (no `Result`); `tii::spec` schema fields are `serde_json::Value`. Needs a version bump per `sdk-spec/release-policy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)