### PR TITLE
fix: facade TaggedArg encoding, native byte arrays, codegen UtxoRef/Address imports

### DIFF
--- a/.trix/client-lib/Cargo.toml.hbs
+++ b/.trix/client-lib/Cargo.toml.hbs
@@ -4,7 +4,9 @@ version = "{{tii.protocol.version}}"
 edition = "2021"
 
 [dependencies]
-tx3-sdk = { version = "^0.13.0" }
+# Floor: the first release carrying `Tx3ClientBuilder::with_tx_params` and
+# `tx3_sdk::tii::params_from_schema`, which this generated client calls.
+tx3-sdk = { version = "^0.15.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/.trix/client-lib/lib.rs.hbs
+++ b/.trix/client-lib/lib.rs.hbs
@@ -5,7 +5,10 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use serde::Serialize;
-use tx3_sdk::core::{ArgMap, TirEncoding, TirEnvelope};
+// `Address` and `UtxoRef` back the params of any transaction that declares
+// them; whether they appear is protocol-dependent, so allow them unused.
+#[allow(unused_imports)]
+use tx3_sdk::core::{Address, ArgMap, TirEncoding, TirEnvelope, UtxoRef};
 use tx3_sdk::trp::ClientOptions;
 use tx3_sdk::{Party, Profile as SdkProfile, Tx3Client, Tx3ClientBuilder, TxBuilder};
 
@@ -54,6 +57,26 @@ pub static {{constantCase @key}}_TIR: LazyLock<TirEnvelope> = LazyLock::new(|| T
     content: "{{tir.content}}".to_string(),
     encoding: TirEncoding::{{pascalCase tir.encoding}},
     version: "{{tir.version}}".to_string(),
+});
+{{/each}}
+
+/// The protocol's `components.schemas` table, embedded verbatim from the TII.
+/// Resolves `#/components/schemas/<Name>` refs inside params schemas.
+static COMPONENT_SCHEMAS: LazyLock<HashMap<String, serde_json::Value>> = LazyLock::new(|| {
+{{#if tii.components.schemas}}
+    serde_json::from_str(r#"{{{json tii.components.schemas}}}"#)
+        .expect("codegen invariant: embedded component schemas parse")
+{{else}}
+    HashMap::new()
+{{/if}}
+});
+
+{{#each tii.transactions}}
+/// Embedded params JSON schema for the `{{@key}}` transaction. Drives
+/// type-directed argument encoding into the TRP wire form at resolve time.
+static {{constantCase @key}}_PARAMS_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
+    serde_json::from_str(r#"{{{json params}}}"#)
+        .expect("codegen invariant: embedded params schema parses")
 });
 {{/each}}
 
@@ -110,6 +133,12 @@ impl Client {
 
         let inner = Tx3ClientBuilder::from_parts(transactions, profiles, Default::default())
             .trp(options)
+{{#each tii.transactions}}
+            .with_tx_params(
+                "{{@key}}",
+                tx3_sdk::tii::params_from_schema(&{{constantCase @key}}_PARAMS_SCHEMA, &COMPONENT_SCHEMAS),
+            )
+{{/each}}
 {{#if tii.profiles}}
             .with_profile(profile.name())
 {{/if}}

--- a/sdk/src/facade.rs
+++ b/sdk/src/facade.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::core::{ArgMap, BytesEnvelope, EnvMap, TirEnvelope};
-use crate::tii::Protocol;
+use crate::tii::{self, ParamMap, Protocol};
 use crate::trp::{self, ResolveParams, SubmitParams, TxStage, TxStatus, TxWitness};
 
 #[derive(Clone)]
@@ -206,6 +206,7 @@ pub struct Profile {
 #[derive(Clone)]
 pub struct Tx3Client {
     transactions: HashMap<String, TirEnvelope>,
+    tx_params: HashMap<String, ParamMap>,
     known_parties: HashSet<String>,
     trp: trp::Client,
     bound_parties: HashMap<String, Party>,
@@ -218,8 +219,10 @@ impl Tx3Client {
     ///
     /// Crate-internal entry used by [`Tx3ClientBuilder::build`]. External
     /// callers go through the builder.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_parts(
         transactions: HashMap<String, TirEnvelope>,
+        tx_params: HashMap<String, ParamMap>,
         known_parties: HashSet<String>,
         trp: trp::Client,
         bound_parties: HashMap<String, Party>,
@@ -232,6 +235,7 @@ impl Tx3Client {
             .collect();
         Self {
             transactions,
+            tx_params,
             known_parties,
             trp,
             bound_parties,
@@ -292,9 +296,12 @@ impl Tx3Client {
             .transactions
             .get(&name)
             .cloned()
-            .ok_or(Error::UnknownTx(name))?;
+            .ok_or_else(|| Error::UnknownTx(name.clone()))?;
+
+        let params = self.tx_params.get(&name).cloned().unwrap_or_default();
 
         Ok(TxBuilder::new(tir, self.trp.clone())
+            .params(params)
             .env(self.env())
             .parties(self.merged_parties()))
     }
@@ -347,6 +354,7 @@ impl Tx3Client {
 /// ```
 pub struct Tx3ClientBuilder {
     transactions: HashMap<String, TirEnvelope>,
+    tx_params: HashMap<String, ParamMap>,
     profiles: HashMap<String, Profile>,
     known_parties: HashSet<String>,
     trp_options: Option<trp::ClientOptions>,
@@ -374,6 +382,7 @@ impl Tx3ClientBuilder {
             .collect();
         Self {
             transactions,
+            tx_params: HashMap::new(),
             profiles,
             known_parties,
             trp_options: None,
@@ -389,6 +398,17 @@ impl Tx3ClientBuilder {
             .txs()
             .iter()
             .map(|(name, tx)| (name.clone(), tx.tir.clone()))
+            .collect();
+
+        let tx_params = protocol
+            .txs()
+            .keys()
+            .filter_map(|name| {
+                protocol
+                    .tx_params(name)
+                    .ok()
+                    .map(|params| (name.clone(), params))
+            })
             .collect();
 
         let profiles = protocol
@@ -408,7 +428,9 @@ impl Tx3ClientBuilder {
 
         let known_parties = protocol.parties().keys().cloned().collect();
 
-        Self::from_parts(transactions, profiles, known_parties)
+        let mut builder = Self::from_parts(transactions, profiles, known_parties);
+        builder.tx_params = tx_params;
+        builder
     }
 
     /// Sets the full TRP client options.
@@ -438,6 +460,20 @@ impl Tx3ClientBuilder {
         opts.headers
             .get_or_insert_with(HashMap::new)
             .insert(key.into(), value.into());
+        self
+    }
+
+    /// Attaches the parameter-type map for a transaction, enabling
+    /// type-directed argument encoding into the TRP `TaggedArg` wire form at
+    /// resolve time (see [`crate::tii::encode`]).
+    ///
+    /// [`Protocol::client`] populates this automatically for every declared
+    /// transaction. Codegen-generated bindings call it with a map built from
+    /// their embedded params schema via [`crate::tii::params_from_schema`]. A
+    /// transaction without a map sends its arguments unencoded, leaving
+    /// coercion to the resolver.
+    pub fn with_tx_params(mut self, tx: impl Into<String>, params: ParamMap) -> Self {
+        self.tx_params.insert(tx.into(), params);
         self
     }
 
@@ -525,6 +561,7 @@ impl Tx3ClientBuilder {
 
         Ok(Tx3Client::from_parts(
             self.transactions,
+            self.tx_params,
             self.known_parties,
             trp,
             bound_parties,
@@ -540,12 +577,20 @@ impl Tx3ClientBuilder {
 /// folded in), bound party addresses, and caller-supplied `args` are merged
 /// into a single argument map, in increasing order of precedence. The request
 /// `env` is left unset — TRP receives one argument map.
+///
+/// Every merged value whose name matches a `params` entry is marshalled by its
+/// `.tii` [`crate::tii::ParamType`] into the TRP `TaggedArg` wire form
+/// (top-level scalars bare, aggregates tagged — see [`crate::tii::encode`]).
+/// An unmapped value has no type, so it passes through untouched. Merged keys
+/// are lowercased on insert while params keep their original case, so the
+/// match is case-insensitive.
 fn build_resolve_params(
     tir: TirEnvelope,
     env: EnvMap,
     parties: &HashMap<String, Party>,
     args: ArgMap,
-) -> ResolveParams {
+    params: &ParamMap,
+) -> Result<ResolveParams, Error> {
     let mut merged = ArgMap::new();
     merged.extend(env);
     for (name, party) in parties {
@@ -556,11 +601,27 @@ fn build_resolve_params(
     }
     merged.extend(args);
 
-    ResolveParams {
+    let encoded = merged
+        .into_iter()
+        .map(|(key, value)| {
+            match params
+                .iter()
+                .find(|(name, _)| name.to_lowercase() == key.to_lowercase())
+            {
+                Some((_, ty)) => {
+                    let value = tii::encode(ty, &value).map_err(tii::Error::from)?;
+                    Ok((key, value))
+                }
+                None => Ok((key, value)),
+            }
+        })
+        .collect::<Result<_, tii::Error>>()?;
+
+    Ok(ResolveParams {
         tir,
-        args: merged,
+        args: encoded,
         env: None,
-    }
+    })
 }
 
 /// Builder for transaction invocation.
@@ -575,6 +636,7 @@ pub struct TxBuilder {
     trp: trp::Client,
     args: ArgMap,
     parties: HashMap<String, Party>,
+    params: ParamMap,
 }
 
 impl TxBuilder {
@@ -592,12 +654,21 @@ impl TxBuilder {
             trp,
             args: ArgMap::new(),
             parties: HashMap::new(),
+            params: ParamMap::new(),
         }
     }
 
     /// Sets the environment values applied to this transaction.
     pub fn env(mut self, env: EnvMap) -> Self {
         self.env = env;
+        self
+    }
+
+    /// Sets the parameter-type map used to marshal argument values into the
+    /// TRP `TaggedArg` wire form at resolve time. Arguments without a matching
+    /// entry pass through unencoded. See [`Tx3ClientBuilder::with_tx_params`].
+    pub fn params(mut self, params: ParamMap) -> Self {
+        self.params = params;
         self
     }
 
@@ -634,9 +705,10 @@ impl TxBuilder {
             trp,
             args,
             parties,
+            params,
         } = self;
 
-        let resolve_params = build_resolve_params(tir, env, &parties, args);
+        let resolve_params = build_resolve_params(tir, env, &parties, args, &params)?;
 
         let envelope = trp.resolve(resolve_params).await?;
 
@@ -1317,7 +1389,8 @@ mod tests {
         let mut args = ArgMap::new();
         args.insert("quantity".to_string(), serde_json::json!(10_000_000));
 
-        let params = build_resolve_params(sample_tir(), env, &parties, args);
+        let params =
+            build_resolve_params(sample_tir(), env, &parties, args, &ParamMap::new()).unwrap();
 
         assert_eq!(params.env, None);
         assert_eq!(params.tir.content, "abcd");
@@ -1343,7 +1416,9 @@ mod tests {
         let mut args = ArgMap::new();
         args.insert("quantity".to_string(), serde_json::json!(999));
 
-        let params = build_resolve_params(sample_tir(), env, &HashMap::new(), args);
+        let params =
+            build_resolve_params(sample_tir(), env, &HashMap::new(), args, &ParamMap::new())
+                .unwrap();
 
         assert_eq!(
             params.args.get("quantity").unwrap(),
@@ -1361,11 +1436,156 @@ mod tests {
         let mut parties = HashMap::new();
         parties.insert("sender".to_string(), Party::signer(stub));
 
-        let params = build_resolve_params(sample_tir(), EnvMap::new(), &parties, ArgMap::new());
+        let params = build_resolve_params(
+            sample_tir(),
+            EnvMap::new(),
+            &parties,
+            ArgMap::new(),
+            &ParamMap::new(),
+        )
+        .unwrap();
 
         assert_eq!(
             params.args.get("sender").unwrap(),
             &serde_json::json!("addr_signer")
+        );
+    }
+
+    /// Interprets a JSON schema node into a [`ParamType`] the way the SDK reads
+    /// a `.tii` params schema.
+    fn param_of(schema: serde_json::Value) -> crate::tii::ParamType {
+        crate::tii::ParamType::from_json_schema(&schema, &HashMap::new())
+    }
+
+    #[test]
+    fn resolve_params_encode_typed_args_to_tagged_wire_form() {
+        // The facade resolve path (used by both the dynamic client and
+        // codegen-generated bindings) must marshal typed args into the
+        // `TaggedArg` wire form — regression for Hydra `init`
+        // `participants: vec![vec![1, 2]]` reaching the resolver raw and
+        // failing with `(-32005) value is not bytes: [1,2]`.
+        let mut params = ParamMap::new();
+        params.insert(
+            "participants".to_string(),
+            param_of(serde_json::json!({
+                "type": "array",
+                "items": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }
+            })),
+        );
+        params.insert(
+            "head_id".to_string(),
+            param_of(
+                serde_json::json!({ "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }),
+            ),
+        );
+
+        let mut args = ArgMap::new();
+        args.insert("participants".to_string(), serde_json::json!([[1, 2]]));
+        args.insert("head_id".to_string(), serde_json::json!("abcd0123"));
+
+        let resolve =
+            build_resolve_params(sample_tir(), EnvMap::new(), &HashMap::new(), args, &params)
+                .unwrap();
+
+        assert_eq!(
+            resolve.args.get("participants").unwrap(),
+            &serde_json::json!({ "list": [{ "bytes": "0x0102" }] })
+        );
+        // A top-level scalar stays bare; the resolver coerces it.
+        assert_eq!(
+            resolve.args.get("head_id").unwrap(),
+            &serde_json::json!("abcd0123")
+        );
+    }
+
+    #[test]
+    fn resolve_params_match_param_names_case_insensitively() {
+        // Arg keys are lowercased on set while `.tii` params keep their
+        // original case; the encoder lookup must still find them.
+        let mut params = ParamMap::new();
+        params.insert(
+            "Participants".to_string(),
+            param_of(serde_json::json!({
+                "type": "array",
+                "items": { "type": "integer" }
+            })),
+        );
+
+        let mut args = ArgMap::new();
+        args.insert("participants".to_string(), serde_json::json!([7]));
+
+        let resolve =
+            build_resolve_params(sample_tir(), EnvMap::new(), &HashMap::new(), args, &params)
+                .unwrap();
+
+        assert_eq!(
+            resolve.args.get("participants").unwrap(),
+            &serde_json::json!({ "list": [{ "int": 7 }] })
+        );
+    }
+
+    #[test]
+    fn resolve_params_pass_unmapped_args_through() {
+        let mut args = ArgMap::new();
+        args.insert("mystery".to_string(), serde_json::json!([[1, 2]]));
+
+        let resolve = build_resolve_params(
+            sample_tir(),
+            EnvMap::new(),
+            &HashMap::new(),
+            args,
+            &ParamMap::new(),
+        )
+        .unwrap();
+
+        // No declared type: the value passes through for the resolver to judge.
+        assert_eq!(
+            resolve.args.get("mystery").unwrap(),
+            &serde_json::json!([[1, 2]])
+        );
+    }
+
+    #[test]
+    fn resolve_params_surface_encode_errors_preflight() {
+        let mut params = ParamMap::new();
+        params.insert(
+            "name".to_string(),
+            param_of(
+                serde_json::json!({ "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }),
+            ),
+        );
+
+        let mut args = ArgMap::new();
+        args.insert("name".to_string(), serde_json::json!(42));
+
+        let result =
+            build_resolve_params(sample_tir(), EnvMap::new(), &HashMap::new(), args, &params);
+
+        assert!(matches!(
+            result,
+            Err(Error::Tii(crate::tii::Error::EncodeArg(_)))
+        ));
+    }
+
+    #[test]
+    fn client_tx_wires_protocol_params_into_builder() {
+        // `Protocol::client()` must thread each transaction's param types into
+        // the facade so `resolve()` encodes typed args — the dynamic-path
+        // equivalent of codegen's `with_tx_params`.
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let tii = format!("{manifest_dir}/tests/fixtures/transfer.tii");
+        let protocol = crate::tii::Protocol::from_file(&tii).unwrap();
+
+        let client = protocol
+            .client()
+            .trp_endpoint("http://localhost:0")
+            .build()
+            .unwrap();
+
+        let builder = client.tx("transfer").unwrap();
+        assert!(
+            !builder.params.is_empty(),
+            "tx builder must receive the protocol's param types"
         );
     }
 }

--- a/sdk/src/tii/encode.rs
+++ b/sdk/src/tii/encode.rs
@@ -99,7 +99,21 @@ fn marshal(param: &ParamType, value: &Value, nested: bool) -> Result<Value, Enco
         },
         ParamType::Bytes => match value {
             Value::String(_) | Value::Object(_) => Ok(leaf("bytes", value, nested)),
-            other => Err(wrong_shape("bytes", "hex string or bytes envelope", other)),
+            // A native byte array (e.g. a codegen `Vec<u8>` param) serializes to
+            // a JSON array of integers; canonicalize it to 0x-prefixed hex, the
+            // wire form the resolver coerces (SDK spec §3.9).
+            Value::Array(items) => {
+                let bytes = byte_array(items).ok_or_else(|| {
+                    wrong_shape("bytes", "hex string, bytes envelope, or byte array", value)
+                })?;
+                let hex = Value::String(format!("0x{}", hex::encode(bytes)));
+                Ok(leaf("bytes", &hex, nested))
+            }
+            other => Err(wrong_shape(
+                "bytes",
+                "hex string, bytes envelope, or byte array",
+                other,
+            )),
         },
         ParamType::Address => match value {
             Value::String(_) => Ok(leaf("address", value, nested)),
@@ -174,6 +188,15 @@ fn marshal(param: &ParamType, value: &Value, nested: bool) -> Result<Value, Enco
         // through and let the resolver coerce it via the flat type.
         ParamType::Utxo | ParamType::AnyAsset | ParamType::Unknown(_) => Ok(value.clone()),
     }
+}
+
+/// Interprets a JSON array as raw bytes: every element must be an integer in
+/// `0..=255`. `None` if any element is not.
+fn byte_array(items: &[Value]) -> Option<Vec<u8>> {
+    items
+        .iter()
+        .map(|v| v.as_u64().filter(|b| *b <= u8::MAX as u64).map(|b| b as u8))
+        .collect()
 }
 
 /// Renders a scalar leaf: bare at the top level (the resolver knows the param's
@@ -362,6 +385,92 @@ mod tests {
         assert_eq!(
             encode(&list, &json!([5])).unwrap(),
             json!({ "list": [{ "int": 5 }] })
+        );
+    }
+
+    fn bytes_schema() -> Value {
+        json!({ "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" })
+    }
+
+    fn list_of_bytes_schema() -> Value {
+        json!({ "type": "array", "items": bytes_schema() })
+    }
+
+    #[test]
+    fn native_byte_arrays_canonicalize_to_hex() {
+        // A codegen `Vec<u8>` param serializes to a JSON array of integers; the
+        // encoder must canonicalize it to 0x-prefixed hex, not send it raw
+        // (regression: TRP `(-32005) value is not bytes: [1,1]`).
+        let bytes = param_type(&bytes_schema(), &HashMap::new());
+        assert_eq!(
+            encode(&bytes, &json!([1, 1])).unwrap(),
+            json!("0x0101"),
+            "top-level byte array renders bare canonical hex"
+        );
+
+        let list = param_type(&list_of_bytes_schema(), &HashMap::new());
+        assert_eq!(
+            encode(&list, &json!([[1, 2]])).unwrap(),
+            json!({ "list": [{ "bytes": "0x0102" }] }),
+            "nested byte array renders tagged canonical hex"
+        );
+    }
+
+    #[test]
+    fn rejects_non_byte_arrays_for_bytes() {
+        let bytes = param_type(&bytes_schema(), &HashMap::new());
+        assert!(encode(&bytes, &json!([1, 256])).is_err());
+        assert!(encode(&bytes, &json!([1, -1])).is_err());
+        assert!(encode(&bytes, &json!(["aa", 1])).is_err());
+        assert!(encode(&bytes, &json!(true)).is_err());
+    }
+
+    #[test]
+    fn hydra_init_arg_shapes() {
+        // Hydra `init` from the feedback repro: `participants` / `parties` are
+        // `List<Bytes>`, `head_id` is `Bytes`. Both hex-string and native
+        // byte-array element forms must produce a CBOR-decodable list of
+        // byte-strings, never a bare byte-string and never raw arrays
+        // (regression: `(-32005) target type not supported: List` /
+        // `value is not bytes: [1,2]`).
+        let list = param_type(&list_of_bytes_schema(), &HashMap::new());
+
+        // participants as hex strings
+        assert_eq!(
+            encode(&list, &json!(["0102", "0304"])).unwrap(),
+            json!({ "list": [{ "bytes": "0102" }, { "bytes": "0304" }] })
+        );
+        // participants as native byte arrays (`vec![vec![1, 2]]`)
+        assert_eq!(
+            encode(&list, &json!([[1, 2]])).unwrap(),
+            json!({ "list": [{ "bytes": "0x0102" }] })
+        );
+        // parties: same List<Bytes> shape, verifier-key bytes
+        assert_eq!(
+            encode(&list, &json!([[222, 173, 190, 239]])).unwrap(),
+            json!({ "list": [{ "bytes": "0xdeadbeef" }] })
+        );
+        // head_id: scalar Bytes stays bare at the top level
+        let bytes = param_type(&bytes_schema(), &HashMap::new());
+        assert_eq!(
+            encode(&bytes, &json!("abcd0123")).unwrap(),
+            json!("abcd0123")
+        );
+    }
+
+    #[test]
+    fn asteria_name_arg_shapes() {
+        // Asteria `create_ship`: `ship_name` / `pilot_name` are `Bytes` params.
+        // Hex-string input passes through bare; native byte arrays canonicalize
+        // (regression: `(-32005) value is not bytes: [1,1]`).
+        let bytes = param_type(&bytes_schema(), &HashMap::new());
+        assert_eq!(
+            encode(&bytes, &json!("53484950313233")).unwrap(),
+            json!("53484950313233")
+        );
+        assert_eq!(
+            encode(&bytes, &json!([83, 72, 73, 80])).unwrap(),
+            json!("0x53484950")
         );
     }
 }

--- a/sdk/src/tii/mod.rs
+++ b/sdk/src/tii/mod.rs
@@ -79,7 +79,7 @@ mod schema;
 pub mod spec;
 
 pub use encode::{encode, EncodeError};
-pub use schema::{ParamMap, ParamType, VariantCase};
+pub use schema::{params_from_schema, ParamMap, ParamType, VariantCase};
 
 /// Error type for TII operations.
 ///
@@ -273,28 +273,9 @@ impl Protocol {
 
         let mut out = Invocation {
             tir: tx.tir.clone(),
-            params: ParamMap::new(),
+            params: self.params_for(tx),
             args: ArgMap::new(),
         };
-
-        let components: HashMap<String, Value> = self
-            .spec
-            .components
-            .as_ref()
-            .map(|c| c.schemas.clone())
-            .unwrap_or_default();
-
-        for party in self.spec.parties.keys() {
-            out.params.insert(party.to_lowercase(), ParamType::Address);
-        }
-
-        if let Some(env) = &self.spec.environment {
-            out.params
-                .extend(schema::params_from_schema(env, &components));
-        }
-
-        out.params
-            .extend(schema::params_from_schema(&tx.params, &components));
 
         if let Some(profile) = profile {
             if let Some(env) = profile.environment.as_object() {
@@ -308,6 +289,42 @@ impl Protocol {
         }
 
         Ok(out)
+    }
+
+    /// Builds the full parameter-type map a transaction resolves against:
+    /// declared parties (as addresses, lowercased), the protocol environment
+    /// schema, and the transaction's own params schema — the same map
+    /// [`Protocol::invoke`] gives its [`Invocation`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnknownTx`] if `tx` is not declared by the protocol.
+    pub fn tx_params(&self, tx: &str) -> Result<ParamMap, Error> {
+        let tx = self.ensure_tx(tx)?;
+        Ok(self.params_for(tx))
+    }
+
+    fn params_for(&self, tx: &Transaction) -> ParamMap {
+        let components: HashMap<String, Value> = self
+            .spec
+            .components
+            .as_ref()
+            .map(|c| c.schemas.clone())
+            .unwrap_or_default();
+
+        let mut params = ParamMap::new();
+
+        for party in self.spec.parties.keys() {
+            params.insert(party.to_lowercase(), ParamType::Address);
+        }
+
+        if let Some(env) = &self.spec.environment {
+            params.extend(schema::params_from_schema(env, &components));
+        }
+
+        params.extend(schema::params_from_schema(&tx.params, &components));
+
+        params
     }
 
     /// Returns all transactions defined in the protocol.

--- a/sdk/src/tii/schema.rs
+++ b/sdk/src/tii/schema.rs
@@ -18,7 +18,11 @@ pub type ParamMap = HashMap<String, ParamType>;
 /// unrecognized property schemas yield [`ParamType::Unknown`]. `components` is the
 /// TII's `components.schemas` table, used to resolve `#/components/schemas/<Name>`
 /// refs to user-defined record / variant types.
-pub(super) fn params_from_schema(schema: &Value, components: &HashMap<String, Value>) -> ParamMap {
+///
+/// Public so codegen-generated clients can interpret their embedded params
+/// schemas and hand the resulting [`ParamMap`] to
+/// [`crate::Tx3ClientBuilder::with_tx_params`].
+pub fn params_from_schema(schema: &Value, components: &HashMap<String, Value>) -> ParamMap {
     let mut params = ParamMap::new();
 
     if let Some(properties) = schema.get("properties").and_then(Value::as_object) {


### PR DESCRIPTION
## Plan

Tx3 Trellis domain plan `plans/feedback-cba-04-sdks-imports-utxoref-signer-encoding.md` (domain root not yet on a forge; plan ref by path). Executed by `org/coder` under plan dispatch.

**Done criterion (rust-sdk share) — met:**
- A generated client for a protocol with a `UtxoRef` param builds (`cargo build` verified against a Hydra-`init`-shaped TII fixture with `UtxoRef`, `Bytes`, `List<Bytes>`, and `Address` params).
- Hydra `init` (`participants: vec![vec![1,2]]`) and Asteria `create_ship` byte-name args now encode into the `TaggedArg` wire form instead of reaching the resolver raw (`(-32005) target type not supported: List` / `value is not bytes`), pinned by unit tests.

## What changed

1. **`fix(tii)`** — the bytes encoder accepts native byte arrays (a codegen `Vec<u8>` serializes to a JSON integer array) and canonicalizes them to `0x`-prefixed hex, per SDK spec §3.9. Regression tests cover the Hydra `init` `participants`/`parties`/`head_id` and Asteria pilot/ship-name shapes.
2. **`fix(facade)`** — the root-cause trace: the type-directed encoder ran only on the dynamic `tii::Invocation` path; the facade path (`Tx3Client`/`TxBuilder`, used by both hand-written facade code and codegen-generated bindings) sent args raw. `TxBuilder` now carries a `ParamMap` and `build_resolve_params` marshals every matching arg. `Tx3ClientBuilder` threads per-tx params — automatic from a loaded `Protocol` (new `Protocol::tx_params`), explicit for codegen via new `with_tx_params`. `tii::params_from_schema` is now public. `from_parts` is unchanged, so existing generated clients keep compiling (args pass through unencoded, as before).
3. **`fix(codegen)`** — `.trix/client-lib/lib.rs.hbs` imports `UtxoRef` **and** `Address` (same defect class: `schemaTypeFor` emits both bare names; previously any protocol declaring either failed to compile), embeds per-tx params schemas + `components.schemas`, and wires them through `with_tx_params`. Generated `Cargo.toml` floor bumped to `^0.15.0` (first release carrying the new API).

Audit note (plan step 1): no stale `tx3_sdk::signer::` path exists anywhere in this repo — the broken form lives in docs/registry snippets owned by another plan (`feedback-cba-07`).

## Verification

- `cargo test --lib`: 32 passed (23 baseline + 9 new).
- `cargo test --test smoke`: pass. `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- Template end-to-end: `tx3c codegen` (built from `tx3-lang/tx3` at the pinned toolchain commit) rendered `.trix/client-lib` against a fixture with `UtxoRef`/`Bytes`/`List<Bytes>`/`Address` params; the generated crate builds against this branch's SDK.
- Pre-existing finding, not touched: 3 doctests (`Ed25519Signer`, `CardanoSigner`, `Party::signer` examples) fail at the base commit — they use `?` where `tx3_sdk::Error` lacks `From<SignerError>`. CI only runs `cargo test --lib`, so CI is unaffected.

## Escalations / follow-ups

- **Release act (org/founder):** these template fixes reach `trix` users only when the `codegen-v1beta0` tag is re-pointed after a `tx3-sdk` `0.15.0` release publishes — ordering: merge → release 0.15.0 → re-point tag.
- Parity: python-sdk and go-sdk received the mirrored bytes-encoder fix (companion PRs); their facade paths still lack the param-map wiring — filed as a follow-up plan in the domain root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)