### PR TITLE
fix(codegen): widen raw-string delimiters in the rust template

### DIFF
--- a/.github/scripts/codegen-check.sh
+++ b/.github/scripts/codegen-check.sh
@@ -20,7 +20,8 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gen="$(mktemp -d)"
-trap 'rm -rf "$gen"' EXIT
+gen_complex="$(mktemp -d)"
+trap 'rm -rf "$gen" "$gen_complex"' EXIT
 
 tx3c codegen \
   --tii "$repo_root/sdk/tests/fixtures/transfer.tii" \
@@ -75,5 +76,35 @@ tx3-sdk = { path = "$repo_root/sdk" }
 EOF
 
 cargo check --manifest-path "$gen/Cargo.toml"
+
+# The transfer fixture is deliberately plain: no custom types, no UtxoRef
+# params. Render `complex.tii` as well, which carries both. It is the only
+# fixture whose embedded schemas contain local `"$ref":"#/components/schemas/…"`
+# refs, and the only one that exercises the `UtxoRef`/`Address` core imports —
+# the two things a transfer-only check cannot see.
+tx3c codegen \
+  --tii "$repo_root/sdk/tests/fixtures/complex.tii" \
+  --template "$repo_root/.trix/client-lib" \
+  --output "$gen_complex"
+
+# Local component refs must survive into the generated source. A raw string
+# delimited `r#"…"#` is closed early by the `"#` in such a ref, which produces
+# a file that parses as garbage rather than one that is merely wrong.
+grep -qF '#/components/schemas/' "$gen_complex/lib.rs" || {
+  echo "generated lib.rs lost its local component refs"
+  exit 1
+}
+grep -qF 'UtxoRef' "$gen_complex/lib.rs" || {
+  echo "generated lib.rs missing the UtxoRef core import"
+  exit 1
+}
+
+cat >> "$gen_complex/Cargo.toml" <<EOF
+
+[patch.crates-io]
+tx3-sdk = { path = "$repo_root/sdk" }
+EOF
+
+cargo check --manifest-path "$gen_complex/Cargo.toml"
 
 echo "codegen check passed"

--- a/.trix/client-lib/lib.rs.hbs
+++ b/.trix/client-lib/lib.rs.hbs
@@ -21,7 +21,12 @@ pub const TARGET_TII_VERSION: &str = "{{tii.tii.version}}";
 
 {{#if tii.environment}}
 /// JSON Schema of the protocol environment, embedded verbatim from the TII.
-pub const ENVIRONMENT_SCHEMA: &str = r#"{{{json tii.environment}}}"#;
+//
+// Delimited `r####"…"####`, not `r#"…"#`: an embedded schema contains local
+// refs of the form `"$ref":"#/components/schemas/<Name>"`, and that `"#`
+// closes a single-hash raw string early. Four hashes because no JSON schema
+// plausibly contains `"####`.
+pub const ENVIRONMENT_SCHEMA: &str = r####"{{{json tii.environment}}}"####;
 {{/if}}
 
 {{#if tii.profiles}}
@@ -45,7 +50,7 @@ impl Profile {
 
 {{#each tii.profiles}}
 static {{constantCase @key}}_PROFILE: LazyLock<SdkProfile> = LazyLock::new(|| {
-    serde_json::from_str(r#"{{{json this}}}"#)
+    serde_json::from_str(r####"{{{json this}}}"####)
         .expect("codegen invariant: embedded profile parses")
 });
 {{/each}}
@@ -64,7 +69,7 @@ pub static {{constantCase @key}}_TIR: LazyLock<TirEnvelope> = LazyLock::new(|| T
 /// Resolves `#/components/schemas/<Name>` refs inside params schemas.
 static COMPONENT_SCHEMAS: LazyLock<HashMap<String, serde_json::Value>> = LazyLock::new(|| {
 {{#if tii.components.schemas}}
-    serde_json::from_str(r#"{{{json tii.components.schemas}}}"#)
+    serde_json::from_str(r####"{{{json tii.components.schemas}}}"####)
         .expect("codegen invariant: embedded component schemas parse")
 {{else}}
     HashMap::new()
@@ -75,7 +80,7 @@ static COMPONENT_SCHEMAS: LazyLock<HashMap<String, serde_json::Value>> = LazyLoc
 /// Embedded params JSON schema for the `{{@key}}` transaction. Drives
 /// type-directed argument encoding into the TRP wire form at resolve time.
 static {{constantCase @key}}_PARAMS_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
-    serde_json::from_str(r#"{{{json params}}}"#)
+    serde_json::from_str(r####"{{{json params}}}"####)
         .expect("codegen invariant: embedded params schema parses")
 });
 {{/each}}


### PR DESCRIPTION
## The bug

`trix codegen --plugin rust-client` currently emits code that does not compile, for **any protocol declaring a record or variant type**. Shipped in 0.15.0 and live now, since `codegen-v1beta0` points at it.

A protocol with custom types produces params schemas containing local refs:

```json
"params":{"$ref":"#/components/schemas/HeadParameters"}
```

Embedded in an `r#"…"#` raw string, that `"#` closes the string early. On a real protocol (`hydra-heads` `init`) the result is 23 compile errors, none of them near the actual mistake:

```
error: unclosed delimiter
   --> lib.rs:187:25
error: could not compile `hydra-heads` (lib) due to 23 previous errors
```

Four hashes (`r####"…"####`), because no JSON schema plausibly contains `"####`. The fully correct fix is a host-side Rust-string-escaping helper in trix's bindgen, which is a cross-repo change; this is the template-local fix that unblocks users today.

## Why CI didn't catch it

`codegen-check.sh` renders only `sdk/tests/fixtures/transfer.tii`, which has no custom types and no `UtxoRef` param. So the check saw neither this bug nor the `UtxoRef` core import that #47 added — the very thing that release was about.

It now also renders `sdk/tests/fixtures/complex.tii`, already in the repo, carrying `AssetClass`, `Side` and a `UtxoRef` param. The check asserts the local component refs and the `UtxoRef` import survive into the generated source, then compiles it.

## Verification

- Extended check against the **old** template: fails, exactly as a user would have.
- Extended check against **this** template: passes.
- The generated `hydra-heads` client — two `UtxoRef` params, two `List<Bytes>` params — compiles clean against published `tx3-sdk` 0.15.0.

Wants a `0.15.1` patch after merge; `release-policy.md` allows patch versions to advance per SDK, so this does not pull the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)